### PR TITLE
Changes to the TransactionalSendingSpec aimed to aid its readability.

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -15,8 +15,8 @@
  */
 log4j = {
     error ''
-    debug 'grails.plugin.jms'
-    debug 'grails.app.service'
+    info 'grails.plugin.jms'
+    info 'grails.app.service'
 }
 
 beans {


### PR DESCRIPTION
The way the tests in the TransactionalSendingSpec were written didn't aid in understanding the purpose of each of the test. This commit is an attempt to rewrite the verbiage and aid the reader. There is also an exception thrown intentionally as part of one of the tests, the previous message was very cryptic and just confused folks reading the output of `grails test-app`. I rewrote the Exception message to better explain its intentions and added a try-catch to avoid any confusions in the console output.
