### PR TITLE
Update documentation for Grails 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: groovy
 jdk:
-- openjdk7
+- openjdk8
 before_script:
 - rm -rf build
 script: ./travis-build.sh

--- a/src/docs/guide/activeMqExample.gdoc
+++ b/src/docs/guide/activeMqExample.gdoc
@@ -1,4 +1,4 @@
-Getting ActiveMQ up and running as your provider is very simple.  All that is required is adding a runtime dependency on the @activemq-spring@ library in @build.gradle@.
+Getting ActiveMQ up and running as your provider is very simple.  All that is required is adding compile dependencies on the @spring-boot-starter-activemq@ library and @pooled-jms@ library in @build.gradle@.
 
 {code}
 
@@ -7,8 +7,9 @@ Getting ActiveMQ up and running as your provider is very simple.  All that is re
 dependencies {
 
     // ...
-    compile 'org.grails.plugins:jms:2.0.0.M1'
-    runtime 'org.apache.activemq:activemq-spring:5.11.1'
+    compile 'org.grails.plugins:jms:2.0.0.RC2'
+    compile 'org.springframework.boot:spring-boot-starter-activemq'
+    compile 'org.messaginghub:pooled-jms'
 }
 {code}
 
@@ -26,5 +27,20 @@ property names defined under @spring.activmeq@ as shown below.
 spring:
     activemq:
         brokerUrl: vm://localhost
-        pooled: true
+        pool:
+            enabled: true
+    jms:
+        cache:
+            enabled: false
+{code}
+
+Note for those who want to use connection pooling: when @spring.activemq.pool.enabled@ is true then SpringBoot will create a @pooledJmsConnectionFactory@ bean rather than @jmsConnectionFactory@.
+You can add the following line in @resources.groovy@ to use a spring bean alias in order to get around this.
+
+{code}
+beans = {
+
+    // ...
+    springConfig.addAlias('jmsConnectionFactory', 'pooledJmsConnectionFactory')
+}
 {code}

--- a/src/docs/guide/jmsProvider.gdoc
+++ b/src/docs/guide/jmsProvider.gdoc
@@ -3,3 +3,26 @@ The plugin does not include a JMS provider so you must install and configure you
 All you need to provide is one or more [javax.jms.ConnectionFactory|http://java.sun.com/javaee/5/docs/api/javax/jms/ConnectionFactory.html] beans and the plugin takes care of the rest.
 
 The plugin looks for a connection factory bean named @jmsConnectionFactory@.
+
+The default SpringBoot configuration has caching enabled, which results in a bean named @cachingJmsConnectionFactory@ being defined rather than @jmsConnectionFactory@.
+
+To turn caching off, set the configuration property @spring.jms.cache.enabled@ in @application.yml@ like so.
+
+{code}
+spring:
+    jms:
+        cache:
+            enabled: false
+{code}
+
+With caching disabled, there will be a @jmsConnectionFactory@ bean defined.
+
+If you wish to use this plugin with caching enabled, you can add the following line in @resources.groovy@ to use a spring bean alias.
+
+{code}
+beans = {
+
+    // ...
+    springConfig.addAlias('jmsConnectionFactory', 'cachingJmsConnectionFactory')
+}
+{code}

--- a/src/main/groovy/grails/plugin/jms/connection/JmsFallbackConnectionFactory.java
+++ b/src/main/groovy/grails/plugin/jms/connection/JmsFallbackConnectionFactory.java
@@ -14,14 +14,14 @@ import org.apache.commons.logging.LogFactory;
 /**
  * A connection factory that falls back to another connection factory if the primary
  * connection factory fails.
- * <p />
+ * <p></p>
  * If you do not assign a fallback JMS queue, it will try to use a
  * local (i.e.: JVM-resident in-memory)
  * ActiveMQ connection, assuming that {@code org.apache.activemq.ActiveMQConnectionFactory} is
  * a class on the class path. (See
  * <a href="https://activemq.apache.org/activemq-551-release.html#ActiveMQ5.5.1Release-GettingtheBinariesusingMaven2">
  * the ActiveMQ download page's Maven config area</a> for the information necessary to pull it down.)
- * <p />
+ * <p></p>
  * This class is thread-safe, in that it is safe to change the parent no matter what other
  * activity may be going on.
  */


### PR DESCRIPTION
Update the plugin's documentation for Grails 4 users.

Most of the changes were inspired by lessons learned trying to get a Grails 4 project running with this plugin included.
https://github.com/gpc/jms/issues/41