### PR TITLE
Feature - Support autostart flag up for JMS Listener containers

### DIFF
--- a/src/main/groovy/grails/plugin/jms/JmsGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugin/jms/JmsGrailsPlugin.groovy
@@ -123,6 +123,10 @@ JMS integration for Grails.
 
 
     def startListenerContainer(listenerConfig, applicationContext) {
-        applicationContext.getBean(listenerConfig.listenerContainerBeanName).start()
+        def listenerContainer = applicationContext.getBean(listenerConfig.listenerContainerBeanName)
+
+        if (listenerContainer.isAutoStartup()) {
+            listenerContainer.start()
+        }
     }
 }


### PR DESCRIPTION
Added feature for supporting autostartup flag for JMS Listener container.

Here's the issue raised for that: https://github.com/gpc/jms/issues/56